### PR TITLE
Added include for "stdexcept" to address compile issue with gcc 10+

### DIFF
--- a/src/aead.cc
+++ b/src/aead.cc
@@ -26,6 +26,7 @@
 #include <sodium.h>
 #include <cstring>
 #include <array>
+#include <stdexcept>
 #include "aead.h"
 #include "util.h"
 

--- a/src/decrypt.h
+++ b/src/decrypt.h
@@ -27,6 +27,7 @@
 
 #include <memory>
 #include <string>
+#include <stdexcept>
 #include "common.h"
 
 namespace hpenc

--- a/src/kdf.cc
+++ b/src/kdf.cc
@@ -25,6 +25,7 @@
 #include "kdf.h"
 #include "nonce.h"
 #include "util.h"
+#include <stdexcept>
 #include <sodium.h>
 #include <openssl/evp.h>
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -31,6 +31,7 @@
 #include <unistd.h>
 #include <iostream>
 #include <cstdlib>
+#include <stdexcept>
 #include <sodium.h>
 
 using namespace hpenc;

--- a/src/util.cc
+++ b/src/util.cc
@@ -30,6 +30,7 @@
 #include <arpa/inet.h>
 #include <cstring>
 #include <cerrno>
+#include <stdexcept>
 #include "util.h"
 #include "aead.h"
 


### PR DESCRIPTION
I noticed that there's an open issue for a build issue on newer GCC versions, and I have this fix in my tree...I'm far from a C++ developer, but perhaps this can help.